### PR TITLE
Event bubbling

### DIFF
--- a/reflex/src/event.cpp
+++ b/reflex/src/event.cpp
@@ -19,9 +19,17 @@ namespace Reflex
 
 		double time;
 
+		Xot::PSharedImpl<Data> parent;
+
 		Data (bool blocked = false, double time = Xot::time())
-		:	blocked(blocked), time(time)
+		:	blocked(blocked), time(time), parent(NULL)
 		{
+		}
+
+		void block ()
+		{
+			blocked = true;
+			if (parent) parent->block();
 		}
 
 	};// Event::Data
@@ -34,6 +42,7 @@ namespace Reflex
 	Event::Event (const Event* src)
 	:	self(new Data(*src->self))
 	{
+		self->parent = src->self;
 	}
 
 	Event::~Event ()
@@ -43,7 +52,7 @@ namespace Reflex
 	void
 	Event::block ()
 	{
-		self->blocked = true;
+		self->block();
 	}
 
 	bool

--- a/reflex/src/shape.cpp
+++ b/reflex/src/shape.cpp
@@ -432,25 +432,23 @@ namespace Reflex
 	}
 
 	void
-	Shape_call_contact_event (Shape* shape, const ContactEvent& event)
+	Shape_call_contact_event (Shape* shape, ContactEvent* event)
 	{
-		if (!shape)
+		if (!shape || !event)
 			argument_error(__FILE__, __LINE__);
 
-		ContactEvent e = event.dup();
-		shape->on_contact(&e);
+		shape->on_contact(event);
 
-		switch (e.action())
+		switch (event->action())
 		{
-			case ContactEvent::BEGIN: shape->on_contact_begin(&e); break;
-			case ContactEvent::END:   shape->on_contact_end(&e);   break;
+			case ContactEvent::BEGIN: shape->on_contact_begin(event); break;
+			case ContactEvent::END:   shape->on_contact_end(event);   break;
 			default: break;
 		}
 
-		if (e.is_blocked())
-			return;
+		if (event->is_blocked()) return;
 
-		View_call_contact_event(shape->owner(), e);
+		View_call_contact_event(shape->owner(), event);
 	}
 
 

--- a/reflex/src/shape.h
+++ b/reflex/src/shape.h
@@ -52,7 +52,7 @@ namespace Reflex
 
 	void Shape_update (Shape* shape, bool force = false);
 
-	void Shape_call_contact_event (Shape* shape, const ContactEvent& event);
+	void Shape_call_contact_event (Shape* shape, ContactEvent* event);
 
 
 }// Reflex

--- a/reflex/src/view.h
+++ b/reflex/src/view.h
@@ -36,13 +36,13 @@ namespace Reflex
 
 	void View_update_shapes (View* view);
 
-	void View_call_key_event     (View* view, const KeyEvent& event);
+	void View_call_key_event     (View* view, KeyEvent* event);
 
-	void View_call_pointer_event (View* view, const PointerEvent& event);
+	void View_call_pointer_event (View* view, PointerEvent* event);
 
-	void View_call_wheel_event   (View* view, const WheelEvent& event);
+	void View_call_wheel_event   (View* view, WheelEvent* event);
 
-	void View_call_contact_event (View* view, const ContactEvent& event);
+	void View_call_contact_event (View* view, ContactEvent* event);
 
 
 }// Reflex

--- a/reflex/src/world.cpp
+++ b/reflex/src/world.cpp
@@ -251,8 +251,9 @@ namespace Reflex
 		if (!View_is_active(*s1->owner()) || !View_is_active(*s2->owner()))
 			return;
 
-		Shape_call_contact_event(s1, ContactEvent(ContactEvent::BEGIN, s2));
-		Shape_call_contact_event(s2, ContactEvent(ContactEvent::BEGIN, s1));
+		ContactEvent e1(ContactEvent::BEGIN, s2), e2(ContactEvent::BEGIN, s1);
+		Shape_call_contact_event(s1, &e1);
+		Shape_call_contact_event(s2, &e2);
 	}
 
 	void
@@ -267,8 +268,9 @@ namespace Reflex
 		if (!View_is_active(*s1->owner()) || !View_is_active(*s2->owner()))
 			return;
 
-		Shape_call_contact_event(s1, ContactEvent(ContactEvent::END, s2));
-		Shape_call_contact_event(s2, ContactEvent(ContactEvent::END, s1));
+		ContactEvent e1(ContactEvent::END, s2), e2(ContactEvent::END, s1);
+		Shape_call_contact_event(s1, &e1);
+		Shape_call_contact_event(s2, &e2);
 	}
 
 

--- a/reflex/test/test_event.rb
+++ b/reflex/test/test_event.rb
@@ -15,16 +15,30 @@ class TestEvent < Test::Unit::TestCase
     e2 = e1.dup
     e1.block
     e3 = e1.dup
-    assert_equal true,  e1.blocked?
-    assert_equal false, e2.blocked?
-    assert_equal true,  e3.blocked?
+    assert_true  e1.blocked?
+    assert_false e2.blocked?
+    assert_true  e3.blocked?
   end
 
   def test_block()
     e = event
-    assert_equal false, e.blocked?
+    assert_false e.blocked?
     e.block
-    assert_equal true,  e.blocked?
+    assert_true  e.blocked?
+  end
+
+  def test_block_propagation()
+    e1 = event
+    e2 = e1.dup
+    e3 = e2.dup
+    assert_false e1.blocked?
+    assert_false e2.blocked?
+    assert_false e3.blocked?
+
+    e2.block
+    assert_true  e1.blocked?
+    assert_true  e2.blocked?
+    assert_false e3.blocked?
   end
 
   def test_time()


### PR DESCRIPTION
PointerEvent と WheelEvent は、子 View で block() されたら親 VIew へはイベントを届けないように修正。
Fixed PointerEvent and WheelEvent so that they do not send events to the parent VIew if they are block()'d in the child View.